### PR TITLE
Add bund.dev API integration

### DIFF
--- a/Python Task/bund_api_client.py
+++ b/Python Task/bund_api_client.py
@@ -1,0 +1,43 @@
+import os
+import requests
+
+BASE_URL = "https://interpol.api.bund.dev"
+API_KEY = os.getenv("INTERPOL_API_KEY")
+
+HEADERS = {
+    "Accept": "application/json",
+}
+
+if API_KEY:
+    HEADERS["x-api-key"] = API_KEY
+
+def search_individual(name=None, nationality=None, dob=None):
+    """Search for individuals by name, nationality or date of birth."""
+    params = {}
+    if name:
+        params["name"] = name
+    if nationality:
+        params["nationality"] = nationality
+    if dob:
+        params["dob"] = dob
+    response = requests.get(f"{BASE_URL}/search", headers=HEADERS, params=params)
+    response.raise_for_status()
+    return response.json()
+
+def get_individual_details(individual_id):
+    """Retrieve detailed information about a specific individual."""
+    response = requests.get(f"{BASE_URL}/individual/{individual_id}", headers=HEADERS)
+    response.raise_for_status()
+    return response.json()
+
+def get_red_notice(individual_id):
+    """View the red notice associated with a specific individual."""
+    response = requests.get(f"{BASE_URL}/red-notice/{individual_id}", headers=HEADERS)
+    response.raise_for_status()
+    return response.json()
+
+if __name__ == "__main__":
+    # Example usage
+    result = search_individual(name="John Doe", nationality="USA")
+    print(result)
+

--- a/Python Task/interpol_full_scrape.py
+++ b/Python Task/interpol_full_scrape.py
@@ -1,8 +1,12 @@
+import os
 import requests
 import time
 import json
 
-BASE_URL = "https://ws-public.interpol.int/notices/v1/red"
+# Base URL optionally overridable to support different endpoints, e.g.
+# https://interpol.api.bund.dev
+BASE_URL = os.getenv("INTERPOL_BASE_URL", "https://ws-public.interpol.int/notices/v1/red")
+API_KEY = os.getenv("INTERPOL_API_KEY")
 RESULTS_PER_PAGE = 160  # Sayfa başına maksimum sonuç sayısı
 
 headers = {
@@ -10,6 +14,10 @@ headers = {
     "Accept": "application/json, text/plain, */*",
     "Referer": "https://www.interpol.int/",
 }
+
+if API_KEY:
+    # Custom API endpoints may require an API key for authentication
+    headers["x-api-key"] = API_KEY
 
 def extract_red_notice_data(notice):
     """

--- a/Python Task/readme.md
+++ b/Python Task/readme.md
@@ -59,6 +59,18 @@ Bu proje, Interpol tarafından yayınlanan kırmızı bülten (Red Notice) veril
 - Projeyi Github/Gitlab'a yükleyerek versiyon kontrolü sağlayabilirsiniz.
 - Gelişmiş mimari için kodlar kolayca genişletilebilir.
 
+## Bund.dev API Entegrasyonu
+Projede istenirse Interpol verileri `https://interpol.api.bund.dev/` adresindeki
+REST API kullanılarak da çekilebilir. Bunun için `interpol_full_scrape.py`
+dosyasındaki `INTERPOL_BASE_URL` ve `INTERPOL_API_KEY` ortam değişkenleri
+kullanılır. API anahtarınızı `INTERPOL_API_KEY` olarak tanımlayıp scripti
+aşağıdaki gibi çalıştırabilirsiniz:
+
+```bash
+INTERPOL_BASE_URL=https://interpol.api.bund.dev \
+INTERPOL_API_KEY=<your-key> python interpol_full_scrape.py
+```
+
 ---
 
 **Not:** Eksik veya geliştirilmesi gereken noktalar README'de ve kodda açıklanmıştır. Daha fazla bilgi için PDF görev dosyasına bakınız. 


### PR DESCRIPTION
## Summary
- allow overriding API URL and key in `interpol_full_scrape.py`
- document how to use bund.dev API in the README
- add `bund_api_client.py` for simple interactions with the bund.dev API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffe3443d8832dbeb9877683f29282